### PR TITLE
show faded version of cards when selecting new cards

### DIFF
--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -1,7 +1,9 @@
 var pokemon = require('./pokemon.actions');
+var selectedPokemon = require('./selected-pokemon.actions');
 var cardData = require('./card-data.actions');
 
 module.exports = {
   pokemon: pokemon,
+  selectedPokemon: selectedPokemon,
   cardData: cardData,
 };

--- a/src/js/actions/selected-pokemon.actions.js
+++ b/src/js/actions/selected-pokemon.actions.js
@@ -1,0 +1,14 @@
+var constants = require('../constants/selected-pokemon.constants')
+
+function selectPokemon(pokemon) {
+  this.dispatch(constants.SELECT_POKEMON, { pokemon: pokemon });
+}
+
+function addedPokemon() {
+  this.dispatch(constants.ADDED_POKEMON);
+}
+
+module.exports = {
+  selectPokemon: selectPokemon,
+  addedPokemon: addedPokemon
+};

--- a/src/js/components/pokemon-add.jsx
+++ b/src/js/components/pokemon-add.jsx
@@ -52,7 +52,7 @@ var PokemonAdd = React.createClass({
           <Col md={1} mdOffset={3}>
             <div className="form-group">
               <label>Quantity</label>
-              <input type="number" className="form-control width-100" valueLink={this.linkState('quantity')} min="0" />
+              <input type="number" value={this.state.quantity} className="form-control width-100" onChange={this.updateQuantity} min="0" />
             </div>
           </Col>
           <Col md={3}>
@@ -76,7 +76,21 @@ var PokemonAdd = React.createClass({
     );
   },
 
+  updateQuantity: function(event) {
+    this.setState({quantity:event.target.value});
+    this.props.onSelectPokemon({
+      quantity: parseInt(event.target.value),
+      card: this.state.card
+    });
+  },
+
   updateCard: function(value) {
+    if (value !== "") {
+      this.props.onSelectPokemon({
+        quantity: parseInt(this.state.quantity),
+        card: value
+      });
+    }
     this.setState({card: value});
   },
 

--- a/src/js/components/pokemon-app.jsx
+++ b/src/js/components/pokemon-app.jsx
@@ -18,12 +18,13 @@ var TabletopButton = require('./tabletop-button');
 
 var PokemonApp = React.createClass({
 
-  mixins: [FluxMixin, StoreWatchMixin('PokemonStore', 'CardDataStore')],
+  mixins: [FluxMixin, StoreWatchMixin('PokemonStore', 'SelectedPokemonStore', 'CardDataStore')],
 
   getStateFromFlux: function() {
     var flux = this.getFlux();
     return {
       pokemon: flux.store('PokemonStore').getState(),
+      selectedPokemon: flux.store('SelectedPokemonStore').getState(),
       cardData: flux.store('CardDataStore').getState()
     };
   },
@@ -38,11 +39,11 @@ var PokemonApp = React.createClass({
         <PageHeader>
           Pokemon Deck Builder
         </PageHeader>
-        <PokemonAdd onAdd={this.onAdd} cards={this.state.cardData} />
+        <PokemonAdd onAdd={this.onAdd} onSelectPokemon={this.onSelectPokemon} cards={this.state.cardData} />
         <hr/>
         <Row>
           <Col md={8}>
-            <PokemonCards pokemon={this.state.pokemon} />
+            <PokemonCards pokemon={this.state.pokemon} selected={this.state.selectedPokemon} />
           </Col>
           <Col md={4}>
             <PokemonList pokemon={this.state.pokemon.pokemon} onRemove={this.onRemove} />
@@ -56,7 +57,12 @@ var PokemonApp = React.createClass({
   },
 
   onAdd: function(pokemon) {
+    this.getFlux().actions.selectedPokemon.addedPokemon();
     this.getFlux().actions.pokemon.addPokemon(pokemon);
+  },
+
+  onSelectPokemon: function(pokemon) {
+    this.getFlux().actions.selectedPokemon.selectPokemon(pokemon);
   },
 
   onRemove: function(index) {

--- a/src/js/components/pokemon-cards.jsx
+++ b/src/js/components/pokemon-cards.jsx
@@ -11,15 +11,26 @@ var PokemonCards = React.createClass({
     return p.set + '-' + p.number + '-' + i;
   },
   render: function() {
+    var cards = this.props.pokemon.pokemonToCards().map((p, i) => {
+      return (
+        <Col md={3} sm={3} xs={3} key={this.key(p, i)}>
+          <PokemonCard card={p.card} />
+        </Col>
+      );
+    });
+
+    var selected = this.props.selected.selectedToCards().map((p, i) => {
+      return (
+        <Col md={3} sm={3} xs={3} key={this.key(p, i)} style={{opacity:.50}}>
+          <PokemonCard card={p.card} />
+        </Col>
+      );
+    });
+
     return (
       <Row>
-        {this.props.pokemon.pokemonToCards().map((p, i) => {
-          return (
-            <Col md={3} sm={3} xs={3} key={this.key(p, i)}>
-              <PokemonCard card={p.card} />
-            </Col>
-          );
-        })}
+        {cards}
+        {selected}
       </Row>
     );
   }

--- a/src/js/components/pokemon-cards.jsx
+++ b/src/js/components/pokemon-cards.jsx
@@ -29,8 +29,8 @@ var PokemonCards = React.createClass({
 
     return (
       <Row>
-        {cards}
         {selected}
+        {cards}
       </Row>
     );
   }

--- a/src/js/constants/selected-pokemon.constants.js
+++ b/src/js/constants/selected-pokemon.constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  SELECT_POKEMON: 'SELECT_POKEMON',
+  ADDED_POKEMON: 'ADDED_POKEMON'
+}

--- a/src/js/stores/index.js
+++ b/src/js/stores/index.js
@@ -1,7 +1,9 @@
 var PokemonStore = require('./pokemon.store');
+var SelectedPokemonStore = require('./selected-pokemon.store');
 var CardDataStore = require('./card-data.store');
 
 module.exports = {
   PokemonStore: new PokemonStore(),
+  SelectedPokemonStore: new SelectedPokemonStore(),
   CardDataStore: new CardDataStore(),
 };

--- a/src/js/stores/pokemon.store.js
+++ b/src/js/stores/pokemon.store.js
@@ -13,7 +13,7 @@ var PokemonStore = Fluxxor.createStore({
   },
 
   onAddPokemon: function(payload) {
-    this.pokemon.push(payload.pokemon);
+    this.pokemon.unshift(payload.pokemon);
     this.emit('change');
   },
 

--- a/src/js/stores/selected-pokemon.store.js
+++ b/src/js/stores/selected-pokemon.store.js
@@ -1,0 +1,42 @@
+var Fluxxor = require('fluxxor');
+var constants = require('../constants/selected-pokemon.constants');
+
+var SelectedPokemonStore = Fluxxor.createStore({
+  initialize: function() {
+    this.selectedPokemon = [];
+
+    this.bindActions(
+      constants.SELECT_POKEMON, this.onSelectPokemon,
+      constants.ADDED_POKEMON, this.onAddedPokemon
+    );
+  },
+
+  onSelectPokemon: function(payload) {
+    this.selectedPokemon = [payload.pokemon];
+    this.emit('change');
+  },
+
+  onAddedPokemon: function() {
+    this.selectedPokemon = [];
+    this.emit('change');
+  },
+
+  selectedToCards: function() {
+    var cards = [];
+    _.forEach(this.selectedPokemon, function(pokemon) {
+      _.times(pokemon.quantity, function(n){
+        cards.push(pokemon);
+      });
+    });
+    return cards;
+  },
+
+  getState: function() {
+    return {
+      selectedPokemon: this.selectedPokemon,
+      selectedToCards: this.selectedToCards
+    };
+  }
+});
+
+module.exports = SelectedPokemonStore;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/326557/13695740/6292dec4-e72f-11e5-8254-5318b7ba9317.png)

Creates a new store, the only thing possibly worth tinkering is where the cards appear.. Currently they appear after regular cards, which looks nice when you go to add them, but could be cumbersome if users have exceedingly large decks.
